### PR TITLE
fix for S3Object ConnectionPoolTimeoutException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,13 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/shared/SharedPlan.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/shared/SharedPlan.java
@@ -149,8 +149,7 @@ public class SharedPlan implements Plan {
 
     private SharedCredentials getSharedCredentialsFromBucket() {
         String sharedCredentialsPath = String.format("%s/%s", CONFIG_DIR, CREDENTIALS_FILENAME);
-        AmazonS3 s3client = brokerConfiguration.amazonS3();
-        try (S3Object sharedCredentials = s3client.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), sharedCredentialsPath))) {
+        try (S3Object sharedCredentials = s3.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), sharedCredentialsPath))) {
             if (sharedCredentials != null) {
                 ObjectMapper mapper = new ObjectMapper();
                 try {

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/shared/SharedPlan.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/shared/SharedPlan.java
@@ -85,7 +85,7 @@ public class SharedPlan implements Plan {
             if ("NoSuchKey".equals(e.getErrorCode())) {
                 logger.error("The S3 object '{}/{}' doesn't exist.", bucket, path);
             } else {
-                logger.error("Undefined error on getJSONFromS3Object()", e);
+                logger.error("Undefined error on getObjectFromS3()", e);
             }
         }
         return null;
@@ -102,9 +102,12 @@ public class SharedPlan implements Plan {
     }
 
     private <T> T getObjectFromJSONOnS3(String bucket, String path, Class<T> returnObject) {
-        S3Object s3object = getObjectFromS3(bucket, path);
-        if(s3object != null) {
-            return readObjectFromS3Object(s3object, returnObject);
+        try (S3Object s3object = getObjectFromS3(bucket, path)) {
+            if (s3object != null) {
+                return readObjectFromS3Object(s3object, returnObject);
+            }
+        } catch (IOException e) {
+            logger.error("IOException on getObjectFromJSONOnS3()", e);
         }
         return null;
     }
@@ -147,14 +150,17 @@ public class SharedPlan implements Plan {
     private SharedCredentials getSharedCredentialsFromBucket() {
         String sharedCredentialsPath = String.format("%s/%s", CONFIG_DIR, CREDENTIALS_FILENAME);
         AmazonS3 s3client = brokerConfiguration.amazonS3();
-        S3Object sharedCredentials = s3client.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), sharedCredentialsPath));
-        if (sharedCredentials != null) {
-            ObjectMapper mapper = new ObjectMapper();
-            try {
-                return mapper.readValue(new InputStreamReader(sharedCredentials.getObjectContent()), SharedCredentials.class);
-            } catch (IOException e) {
-                logger.error("Could not read shared credentials from S3 bucket.", e);
+        try (S3Object sharedCredentials = s3client.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), sharedCredentialsPath))) {
+            if (sharedCredentials != null) {
+                ObjectMapper mapper = new ObjectMapper();
+                try {
+                    return mapper.readValue(new InputStreamReader(sharedCredentials.getObjectContent()), SharedCredentials.class);
+                } catch (IOException e) {
+                    logger.error("Could not read shared credentials from S3 bucket.", e);
+                }
             }
+        } catch (IOException e) {
+            logger.error("IOException on getSharedCredentialsFromBucket()", e);
         }
         return null;
     }
@@ -232,11 +238,13 @@ public class SharedPlan implements Plan {
     @Override
     public ServiceInstance getServiceInstance(String id) {
         String instanceConfigPath = getInstanceConfigPath(id);
-        S3Object s3Object = s3.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), instanceConfigPath));
-        if (s3Object != null) {
-            return new ServiceInstance(id, null, planId, null, null, null);
-        } else {
-            return null;
+        try (S3Object s3Object = s3.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), instanceConfigPath))) {
+            if (s3Object != null) {
+                return new ServiceInstance(id, null, planId, null, null, null);
+            }
+        } catch (IOException e) {
+            logger.error("IOException on getServiceInstance()", e);
         }
+        return null;
     }
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/singlebucket/SingleBucketPlan.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/singlebucket/SingleBucketPlan.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -160,11 +161,13 @@ public class SingleBucketPlan implements Plan {
     @Override
     public ServiceInstance getServiceInstance(String id) {
         String instanceConfigPath = getInstanceConfigPath(id);
-        S3Object s3Object = s3.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), instanceConfigPath));
-        if (s3Object != null) {
-            return new ServiceInstance(id, null, planId, null, null, null);
-        } else {
-            return null;
+        try (S3Object s3Object = s3.getObject(new GetObjectRequest(brokerConfiguration.getSharedBucket(), instanceConfigPath))) {
+            if (s3Object != null) {
+                return new ServiceInstance(id, null, planId, null, null, null);
+            }
+        } catch (IOException e) {
+            logger.error("IOException on getServiceInstance()", e);
         }
+        return null;
     }
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/service/S3.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/service/S3.java
@@ -179,6 +179,16 @@ public class S3 {
         return s3.createBucket(bucket, region);
     }
 
+    /**
+     * Caution: S3Object opens a connection for each object.
+     * These connections are not liberated even if the object is garbage collected,
+     * so it is needed to execute either use Try-with-resources (preferred)
+     * or manually call object.close() in order to liberate the connection to the pool.
+     * Failing to do so will result in AmazonClientException: ConnectionPoolTimeoutException.
+     *
+     * @param getObjectRequest
+     * @return Returns the requested {@link S3Object}.
+     */
     public S3Object getObject(GetObjectRequest getObjectRequest) {
         return s3.getObject(getObjectRequest);
     }


### PR DESCRIPTION
S3Object opens a connection for each object.
These connections are not liberated even if the object is garbage collected,
so it is needed to execute either use Try-with-resources (preferred)
or manually call object.close() in order to liberate the connection to the pool.
Failing to do so will result in AmazonClientException: ConnectionPoolTimeoutException.

More information can be found here:
- http://stackoverflow.com/questions/17782937/connectionpooltimeoutexception-when-iterating-objects-in-s3
- https://forums.aws.amazon.com/message.jspa?messageID=471149
- https://java.awsblog.com/post/Tx22D24MCRWFR9U/Closeable-S3Objects
- http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/S3Object.html
